### PR TITLE
"styled-system": "^5.1.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-native-draganddrop-board": "https://github.com/bear-junior/react-native-draganddrop-board",
     "react-timeout": "^1.2.0",
     "styled-components": "^4.4.1",
-    "styled-system": "^5.1.2"
+    "styled-system": "^5.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",


### PR DESCRIPTION
"styled-system": "^5.1.2" > 5.1.2 hangs the installing process. It is better to use latest version 5.1.4