### PR TITLE
Fixes the Item isVisible logic 

### DIFF
--- a/src/components/lib/Item.js
+++ b/src/components/lib/Item.js
@@ -53,7 +53,11 @@ class Item {
     const measure = ref && ref.measure((fx, fy, width, height, px, py) => {
       const layout = { x: px, y: py, width, height }
       this.setLayout(layout)
-      if (!this.isVisible() && layout.x && layout.y && layout.width && layout.height) {
+      if (!this.isVisible() &&
+          (layout.x || layout.x === 0) &&
+          (layout.y || layout.y === 0) &&
+          (layout.width || layout.width === 0) &&
+          (layout.height || layout.height === 0)) {
         this.setVisible(true)
       } else if (this.isVisible() && !layout.x && !layout.y && !layout.width && !layout.height) {
         this.setVisible(false)


### PR DESCRIPTION
The Item isVisible logic is failing if one of the layout constraints is 0.

Being zero was treated the same as being null or undefined (falsy).

The issue arise when removing the padding or margin in the ColumnWrapper